### PR TITLE
use openlib instead of dlopen

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 Cairo
+OpenLib

--- a/src/Tk.jl
+++ b/src/Tk.jl
@@ -11,18 +11,20 @@
 # - cleaning up unused callbacks
 
 require("Cairo")
+require("OpenLib")
 
 module Tk
 using Base
 using Cairo
+using OpenLib
 
 export Window, Button, TkCanvas, Canvas, pack, place, tcl_eval, TclError,
     cairo_surface_for, width, height, reveal, cairo_context, cairo_surface,
     tcl_doevent, MouseHandler
 
-libtcl = dlopen("libtcl8.5")
-libtk = dlopen("libtk8.5")
-libX = dlopen("libX11")
+libtcl = openlib("libtcl8.5")
+libtk = openlib("libtk8.5")
+libX = openlib("libX11")
 tk_wrapper = dlopen("libtk_wrapper")
 
 tcl_doevent() = tcl_doevent(0)


### PR DESCRIPTION
Fixes

```
julia> require("Tk")
could not load module libtcl8.5: libtcl8.5: cannot open shared object file: No such file or directory
```

on ubuntu.
