### PR TITLE
Minor fix for building against homebrew tk/tcl.

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -58,6 +58,7 @@ cc = CCompile("src/tk_wrapper.c","$prefix/lib/libtk_wrapper.$shlib_ext",
          "-L$prefix/lib"],
                 OS_NAME == :Linux ? ["-ltcl8.5","-ltk8.5"] : ["-ltcl","-ltk"])
 if(OS_NAME == :Darwin)
+    push!(cc.options, "-I/opt/X11/include")
     unshift!(cc.options,"-xobjective-c")
     append!(cc.libs,["-framework","AppKit","-framework","Foundation","-framework","ApplicationServices"])
 elseif(OS_NAME == :Windows)

--- a/deps/src/tk_wrapper.c
+++ b/deps/src/tk_wrapper.c
@@ -55,7 +55,7 @@ void *jl_tkwin_hdc_release(HDC hdc)
 #define MAC_OSX_TK
 #import <Cocoa/Cocoa.h>
 #include "ApplicationServices/ApplicationServices.h"
-#include "TkMacOSXInt.h"
+#include "tkMacOSXInt.h"
 
 /* This thing is the cause of a lot of pain and suffering. In order to make this work correctly,
  * you need to make sure that the latest cached drawing context is that in which you want cairo to draw.


### PR DESCRIPTION
Homebrew deletes the X11 headers installed by tk. Need to add the XQuartz
headers to the include path when compiling.
