### PR TITLE
Add parent & toplevel functions

### DIFF
--- a/src/Tk.jl
+++ b/src/Tk.jl
@@ -17,7 +17,7 @@ using Base
 using Cairo
 
 
-import Base: string, show, getindex, setindex!
+import Base: string, show, getindex, setindex!, isequal
 import Base.Graphics: width, height, getgc
 
 include("tkwidget.jl")                  # old Tk
@@ -60,6 +60,7 @@ export get_value, set_value,
        get_editable, set_editable,
        get_visible, set_visible,
        set_position,
+       parent, toplevel,
        raise, focus, update, destroy
 
 

--- a/src/containers.jl
+++ b/src/containers.jl
@@ -5,7 +5,7 @@ type Tk_Labelframe  <: TTk_Container w::TkWidget end
 type Tk_Notebook    <: TTk_Container w::TkWidget end
 type Tk_Panedwindow <: TTk_Container w::TkWidget end
 
-
+isequal(a::TTk_Container, b::TTk_Container) = isequal(a.w, b.w) && typeof(a) == typeof(b)
 
 ## Toplevel window
 function Toplevel(;title::String="Toplevel Window", width::Integer=200, height::Integer=200, visible::Bool=true)
@@ -197,3 +197,22 @@ function scrollbars_add(parent::Tk_Frame, child::Tk_Widget)
     
 end
 
+# Navigating hierarchies
+
+# parent returns a TkWidget, because we don't know how to wrap it otherwise (?)
+parent(w::TkWidget) = w.parent
+parent(w::Tk_Widget) = parent(w.w)
+parent(c::Canvas) = parent(c.c)
+
+# For toplevel it's obvious how to wrap it...
+function toplevel(w::Union(TkWidget, Tk_Widget, Canvas))
+    p = parent(w)
+    pold = p
+    while !is(p, nothing)
+        pold = p
+        p = parent(p)
+    end
+    Tk_Toplevel(pold)
+end
+
+toplevel(w::Tk_Toplevel) = w

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -8,6 +8,8 @@ set_position(w, 10, 10)
 set_value(w, "Toplevel 2")
 @assert get_value(w) == "Toplevel 2"
 @assert get_size(w) == [400, 400]
+p = toplevel(w)
+@assert p == w
 destroy(w)
 @assert !exists(w)
 
@@ -17,6 +19,8 @@ pack_stop_propagate(w)
 f = Frame(w)
 pack(f, expand=true, fill="both")
 @assert get_size(w) == [400, 400]
+p = toplevel(f)
+@assert p == w
 destroy(w)
 
 ## Labelframe
@@ -26,6 +30,8 @@ f = Labelframe(w, "Label")
 pack(f, expand=true, fill="both")
 set_value(f, "new label")
 @assert get_value(f) == "new label"
+p = toplevel(f)
+@assert p == w
 destroy(w)
 
 ## notebook
@@ -249,4 +255,13 @@ tree_headers(tr, ["left"], [50])
 scrollbars_add(f, tr)
 set_value(tr, 2)
 @assert get_value(tr)[1] == choices[2]
+destroy(w)
+
+
+## Canvas
+w = Toplevel("Canvas")
+f = Frame(w)
+c = Canvas(f)
+@assert parent(c) == f.w
+@assert toplevel(c) == w
 destroy(w)


### PR DESCRIPTION
These are intended to make it easier to navigate "up" the hierarchy of objects.

Example usage:

```
destroy(toplevel(imgc.c))
```

will close the window associated with a canvas in `imgc.c`. Triggered by https://github.com/timholy/ImageView.jl/issues/3

@jverzani, please let me know if there's a better way to do this, otherwise either of us can merge.
