### PR TITLE
Fixes to Tk on OSX

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -11,7 +11,7 @@ function build()
 
     ## Homebrew
     @osx_only push!(c,Choice(:brew,"Install depdendency using brew",@build_steps begin
-        HomebrewInstall("tk",ASCIIString["--enable-aqua"])
+        HomebrewInstall("https://raw.github.com/Homebrew/homebrew-dupes/master/tcl-tk.rb",ASCIIString[])
     end))
 
     ## Prebuilt Binaries
@@ -58,10 +58,16 @@ function build()
 end
 
 function build_wrapper()
+    include_paths = ["$prefix/include", "/usr/local/include"]
+    lib_paths = ["$prefix/lib"]
+    @osx_only begin
+        insert!(include_paths, 1, "/usr/local/opt/tcl-tk/include")
+        insert!(lib_paths, 1, "/usr/local/opt/tcl-tk/lib")
+    end
     cc = CCompile("src/tk_wrapper.c","$prefix/lib/libtk_wrapper."*BinDeps.shlib_ext,
                   ["-shared","-g","-fPIC","-I$prefix/include",
-                   "-I/usr/local/include",
-                   "-L$prefix/lib"],
+                   ["-I$path" for path in include_paths]...,
+                   ["-L$path" for path in lib_paths]...],
                   OS_NAME == :Linux ? ["-ltcl8.5","-ltk8.5"] : OS_NAME == :Darwin ? ["-ltcl8.6","-ltk8.6"] : ["-ltcl","-ltk"])
     if(OS_NAME == :Darwin)
 #        push!(cc.options, "-I/opt/X11/include")

--- a/deps/ext.jl
+++ b/deps/ext.jl
@@ -8,7 +8,16 @@ let
                 dl = dlopen(libname)
                 dlclose(dl)
             catch
-                error("Failed to find required library "*libname*". Try re-running the package script using Pkg.runbuildscript(\"pkg\")")
+                if OS_NAME == :Darwin
+                    try
+                        dl = dlopen(joinpath("/usr/local/opt/tcl-tk/lib",filename))
+                        ccall(:add_library_mapping,Int32,(Ptr{Uint8},Ptr{Uint8}),libname,dl)
+                    catch
+                        error("Failed to find required library "*libname*". Try re-running the package script using Pkg.runbuildscript(\"pkg\")")
+                    end
+                else
+                    error("Failed to find required library "*libname*". Try re-running the package script using Pkg.runbuildscript(\"pkg\")")
+                end
             end
         end
     end


### PR DESCRIPTION
These fixes make Tk compile using `brew` flawlessly on my machine.
- Use the full URL to access the `tcl-tk` formula; no longer need to tap `homebrew-dupes`
- Use opt paths when linking and including; Fixes the X11 headers problem.  This was due to `tcl-tk` being a "keg-only" formula, e.g. it is not linked into `/usr/local/` because it conflicts with OSX's own `tk` installation.
- Use opt paths when dynamically linking, because since `tcl-tk` is "keg-only", it doesn't get linked into `/usr/local/lib`, so we've gotta search in the proper places for them.
