### PR TITLE
remove `using BinDeps`

### DIFF
--- a/src/Tk.jl
+++ b/src/Tk.jl
@@ -14,7 +14,6 @@
 module Tk
 using Base
 using Cairo
-using BinDeps
 
 include("../deps/deps.jl")
 


### PR DESCRIPTION
I believe this is no longer needed at run time.
