### PR TITLE
Fix deprecations.

### DIFF
--- a/examples/manipulate.jl
+++ b/examples/manipulate.jl
@@ -40,8 +40,8 @@ function make_widget(parent, widget::SliderWidget)
 end
 
 slider(nm::String, label::String, rng::Range1, initial::Integer) = SliderWidget(nm, label, initial, rng)
-slider(nm::String, label::String, rng::Range1) = slider(nm, label, rng, min(rng))
-slider(nm::String,  rng::Range1) = slider(nm, nm, rng, min(rng))
+slider(nm::String, label::String, rng::Range1) = slider(nm, label, rng, minimum(rng))
+slider(nm::String,  rng::Range1) = slider(nm, nm, rng, minimum(rng))
 
 
 type PickerWidget <: ManipulateWidget

--- a/src/core.jl
+++ b/src/core.jl
@@ -203,7 +203,7 @@ function callback_add(widget::Tk_Widget, callback::Function)
            :Tk_Treeview => "<<TreeviewSelect>>"
            }
     key = Base.symbol(string(typeof(widget)))
-    if has(events, key)
+    if haskey(events, key)
         event = events[key]
         if event == nothing
             return()


### PR DESCRIPTION
I noticed these while trying the `require(Pkg.dir("Tk", "examples", "manipulate.jl"))` example.
