### PR TITLE
Check `nametowindow` return value for C_NULL

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -203,7 +203,7 @@ function callback_add(widget::Tk_Widget, callback::Function)
            :Tk_Treeview => "<<TreeviewSelect>>"
            }
     key = Base.symbol(string(typeof(widget)))
-    if has(events, key)
+    if haskey(events, key)
         event = events[key]
         if event == nothing
             return()

--- a/src/tkwidget.jl
+++ b/src/tkwidget.jl
@@ -277,6 +277,7 @@ end
 # But, this should be the only such function needed.
 function render_to_cairo(f::Function, w::TkWidget, clipped::Bool=true)
     win = nametowindow(w.path)
+    win == C_NULL && error("invalid window")
     @linux_only begin
         disp = jl_tkwin_display(win)
         d = jl_tkwin_id(win)


### PR DESCRIPTION
(Also rename `has`->`haskey` once... haven't checked for more.)

Should fix the `EXCEPTION_ACCESS_VIOLATION` in https://github.com/kmsquire/VideoIO.jl/issues/32, as well as the segfault noted [here](https://github.com/kmsquire/VideoIO.jl/issues/31#issuecomment-55152203)

At this point, it just throws an error, which is in line with what the rest of the code below it does.  This seems better than a segfault, at least, although I'm wondering if there isn't a better way to handle it (e.g., capturing the window DESTROY event).  But I suspect that's a bigger change.

Cc: @timholy, @Varanas, @maxruby
