### PR TITLE
Fixes `ERROR: LoadError: syntax: "bar::Int=0" inside type definition …

### DIFF
--- a/src/tkwidget.jl
+++ b/src/tkwidget.jl
@@ -103,8 +103,8 @@ type TkWidget
     path::ByteString
     kind::ByteString
     parent::Union(TkWidget,Nothing)
-
-    ID::Int = 0
+    
+    let ID::Int = 0
     function TkWidget(parent::TkWidget, kind)
         underscoredKind = replace(kind, "::", "_")
         path = "$(parent.path).jl_$(underscoredKind)$(ID)"; ID += 1
@@ -120,6 +120,7 @@ type TkWidget
         tcl_eval("wm title $wpath \"$title\"")
         tcl_doevent()
         new(wpath, "toplevel", nothing)
+    end
     end
 end
 


### PR DESCRIPTION
…is reserved` by using a `let` scope. Also see http://stackoverflow.com/questions/31280948/inside-type-definition-is-reserved

Tested on julia 0.4- latest master and 0.3 (latest stable) on ubuntu 14.10.