### PR TITLE
Patching bug of callback failing.

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -203,7 +203,7 @@ function callback_add(widget::Tk_Widget, callback::Function)
         :Tk_Text => "<FocusOut>",
         :Tk_Treeview => "<<TreeviewSelect>>"
     )
-    key = Base.symbol(string(typeof(widget)))
+    key = Base.symbol(split(string(typeof(widget)), '.')[end])
     if haskey(events, key)
         event = events[key]
         if event == nothing


### PR DESCRIPTION
## Bug description
Bug occurs in Julia v0.4-dev (a week old master).
Bug could be tested by running [examples/test.jl](https://github.com/JuliaLang/Tk.jl/blob/master/examples/test.jl). Clicking on anything should print event but it doesn't.

## Way bugs occurs
typeof() return package.type instead of just type, for example Tk.Tk_Window instead of just Tk_Window, so need to take just type name.

## Way should you merge it
Patch is backward compatible (in older versions if typeof() returns type its OK for split and [end]).

## P.S.
Julia is the best and inspire me for my first pull request.
