### PR TITLE
Stop exporting Text to avoid shadowing Base.Text

### DIFF
--- a/src/Tk.jl
+++ b/src/Tk.jl
@@ -19,7 +19,7 @@ using Tk_jll
 using Cairo
 using Random
 
-import Base: ==, bind, getindex, isequal, parent, setindex!, show, string, Text
+import Base: ==, bind, getindex, isequal, parent, setindex!, show, string
 
 import Graphics: width, height, getgc
 
@@ -57,7 +57,7 @@ export Toplevel, Frame, Labelframe, Notebook, Panedwindow
 export Label, Button
 export Checkbutton, Radio, Combobox
 export Slider, Spinbox
-export Entry, set_validation, Text
+export Entry, set_validation
 export Treeview, selected_nodes, node_insert, node_move, node_delete, node_open
 export tree_headers, tree_column_widths, tree_key_header, tree_key_width
 export Sizegrip, Separator, Progressbar, Image, Scrollbar

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -261,7 +261,7 @@ end
     w = Toplevel("Text")
     pack_stop_propagate(w)
     f = Frame(w); pack(f, expand=true, fill="both")
-    txt = Text(f)
+    txt = Tk.Text(f)
     scrollbars_add(f, txt)
     set_value(txt, "new text\n")
     @test get_value(txt) == "new text\n"


### PR DESCRIPTION
## Summary
- Remove `Text` from `import Base:` and `export` lists in `src/Tk.jl`
- The text widget is still accessible as `Tk.Text(parent)`
- Update test to use qualified `Tk.Text(f)` call

This is a minor breaking change for users who relied on the unqualified `Text(...)` export, but it fixes a long-standing conflict where `using Tk` would shadow `Base.Text`.

Fixes #117

## Test plan
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)