### PR TITLE
Fix Tcl/Tk 9 initialization and deprecated API usage

### DIFF
--- a/examples/workspace.jl
+++ b/examples/workspace.jl
@@ -43,7 +43,7 @@ function get_names_summaries(m::Module, pat::MaybeRegex, dtype::MaybeType, dtype
     nms = get_names(m)
 
     if pat != nothing
-        nms = filter(s -> ismatch(pat, s), nms)
+        nms = filter(s -> occursin(pat, s), nms)
     end
     ## filter out this type
     if dtype != nothing

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -1,5 +1,9 @@
 ## Create basic widgets here
 
+# Declare Text as a new function in this module so the @eval loop below
+# does not accidentally extend Base.Text (which exists in Julia >= 1.12).
+function Text end
+
 ## Most structs are simple, some have other properties
 mutable struct Tk_Label       <: TTk_Widget w::TkWidget end
 mutable struct Tk_Button      <: TTk_Widget w::TkWidget end
@@ -360,7 +364,7 @@ function x11encode(data::BitArray{2})
         print(s, u8[i], ",")
     end
     println(s, u8[end], "\n};")
-    takebuf_string(s)
+    String(take!(s))
 end
 
 ## Entry


### PR DESCRIPTION
## Summary
- Set `TCL_LIBRARY` and `TK_LIBRARY` environment variables pointing to the JLL artifact directories before `Tcl_Init`/`Tk_Init`, fixing the "Cannot find a usable init.tcl" error (the JLL-built shared libraries don't reliably auto-mount their zipfs filesystems)
- Declare `function Text end` in the Tk module so the `@eval` widget constructor loop creates `Tk.Text` instead of extending `Base.Text` (fixes Julia 1.12 deprecation warning)
- Fix remaining deprecated API calls: `pointer_to_array` → `unsafe_load`, `takebuf_string` → `String(take!(...))`, `ismatch` → `occursin`

## Test plan
- [x] All 19 test sets pass (42 assertions) with `xvfb-run julia --project -e 'using Pkg; Pkg.test()'`
- [x] Zero warnings in test output
- [ ] CI passes on Ubuntu with Julia 1.6 and latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)